### PR TITLE
Adding budget elements and network endpoints

### DIFF
--- a/makefile
+++ b/makefile
@@ -99,8 +99,11 @@ setup-image-repository: check_aws_login
 # Provision required infrastructure/services for deployment in AWS.
 setup-aws-infrastructure: pipeline-push
 	@echo "Provisioning services in AWS...\n+"
+	@aws ecs put-account-setting --name containerInstanceLongArnFormat --value enabled
+	@aws ecs put-account-setting --name serviceLongArnFormat --value enabled
+	@aws ecs put-account-setting --name taskLongArnFormat --value enabled
 	@terraform init terraform/aws
-	@terraform apply -var client_app_image=$(DEPLOYMENT_IMAGE) terraform/aws
+	@terraform apply -var client_app_image=$(DEPLOYMENT_IMAGE) -var budget_amount=10 terraform/aws
 
 # Set an AWS profile for pipeline
 setup-aws-profile:

--- a/terraform/aws/autoscaling.tf
+++ b/terraform/aws/autoscaling.tf
@@ -5,7 +5,7 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main[count.index].name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = 0
+  min_capacity       = 2
   max_capacity       = 6
 }
 

--- a/terraform/aws/autoscaling.tf
+++ b/terraform/aws/autoscaling.tf
@@ -5,7 +5,7 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main[count.index].name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = 2
+  min_capacity       = 1
   max_capacity       = 6
 }
 

--- a/terraform/aws/autoscaling.tf
+++ b/terraform/aws/autoscaling.tf
@@ -5,7 +5,7 @@ resource "aws_appautoscaling_target" "target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main[count.index].name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = 2
+  min_capacity       = 0
   max_capacity       = 6
 }
 

--- a/terraform/aws/budget.tf
+++ b/terraform/aws/budget.tf
@@ -1,0 +1,27 @@
+
+resource "aws_budgets_budget" "cost" {
+ 
+  name              = "startup-sample-monthly"
+  budget_type       = "COST"
+  limit_amount      = var.budget_amount
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start          = formatdate("YYYY-MM-01_12:00", timestamp())
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 75
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_sns_topic_arns  = [aws_sns_topic.billing_alert_topic.arn]        
+  }
+
+  cost_filters = {
+      TagKeyValue = "user:Project$Startup Sample"
+  }
+}
+
+
+resource "aws_sns_topic" "billing_alert_topic" {
+  name = "startup-sample-billing-alert-topic"
+}

--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -3,6 +3,12 @@
 resource "aws_ecs_cluster" "main" {
   name                = "sample-cluster"
   capacity_providers  = ["FARGATE_SPOT"]
+  
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight = 100
+  }
+
 
   tags = local.common_tags
 }
@@ -41,10 +47,16 @@ resource "aws_ecs_service" "main" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.app[count.index].arn
   desired_count   = var.client_app_count
-  launch_type     = "FARGATE"
+  #launch_type     = "FARGATE"
   enable_ecs_managed_tags = true
   propagate_tags = "TASK_DEFINITION"
 
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight = 100
+  }
+
+  
   network_configuration {
     security_groups  = [aws_security_group.ecs_tasks.id]
     subnets          = aws_subnet.private.*.id

--- a/terraform/aws/ecs.tf
+++ b/terraform/aws/ecs.tf
@@ -42,6 +42,8 @@ resource "aws_ecs_service" "main" {
   task_definition = aws_ecs_task_definition.app[count.index].arn
   desired_count   = var.client_app_count
   launch_type     = "FARGATE"
+  enable_ecs_managed_tags = true
+  propagate_tags = "TASK_DEFINITION"
 
   network_configuration {
     security_groups  = [aws_security_group.ecs_tasks.id]
@@ -56,4 +58,6 @@ resource "aws_ecs_service" "main" {
   }
 
   depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs_task_execution_role]
+
+  tags = local.common_tags
 }

--- a/terraform/aws/network.tf
+++ b/terraform/aws/network.tf
@@ -81,3 +81,31 @@ resource "aws_route_table_association" "private" {
   subnet_id      = element(aws_subnet.private.*.id, count.index)
   route_table_id = element(aws_route_table.private.*.id, count.index)
 }
+
+
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id       = aws_vpc.main.id
+  service_name = "com.amazonaws.${var.aws_region}.dynamodb"
+
+  route_table_ids = aws_route_table.private[*].id
+
+
+  tags = local.common_tags
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.aws_region}.ecr.dkr"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.endpoints.id
+  ]
+
+  subnet_ids = aws_subnet.private[*].id
+
+  private_dns_enabled = true
+
+  tags = local.common_tags
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -3,3 +3,8 @@
 output "alb_hostname" {
   value = aws_alb.main.dns_name
 }
+
+output "sns_topic" {
+  value = aws_sns_topic.billing_alert_topic.arn
+  description = "Subscribe to this topic using your email to receive email alerts from the budget."
+}

--- a/terraform/aws/security.tf
+++ b/terraform/aws/security.tf
@@ -55,3 +55,24 @@ resource "aws_security_group" "ecs_tasks" {
 
 
 
+resource "aws_security_group" "endpoints" {
+  name        = "sample-endpoints-security-group"
+  description = "allow inbound access"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 443
+    to_port         = 443
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.common_tags
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -65,3 +65,12 @@ variable "repository_name" {
   type = string
   default = "ssp"
 }
+
+variable "budget_amount" {
+  description = "The amount of spend for the budget. Example: enter 10 to represent $10"
+}
+
+variable "budget_tag" {
+  description = "The Cost Allocation Tag that will be used to build the monthly budget. "
+  default     = "Project=Startup Sample"
+}


### PR DESCRIPTION
This PR contains changes to terraform and make artifacts to provide better cost control and visibility:

- budget elements provide configurable notifications when certain cost levels are approaching
- using network endpoints selectively in place of NAT gateway is a lower cost option in our use case.